### PR TITLE
add switch to turn off RV clockwork compilation

### DIFF
--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -21342,7 +21342,11 @@ void compile_for_garnet_single_port_mem(prog& prg,
   cout << endl << endl << endl;
 
   const char* dense_ready_valid = std::getenv("DENSE_READY_VALID");
-  if (dense_ready_valid && dense_ready_valid[0] == '1') {
+  bool skip_rv_clockwork = (std::getenv("SKIP_RV_CLOCKWORK") != nullptr) && (std::getenv("SKIP_RV_CLOCKWORK")[0] == '1');
+  if (skip_rv_clockwork) {
+    cout << "SKIP RV CLOCKWORK" << endl;
+  }
+  if (dense_ready_valid && dense_ready_valid[0] == '1' && !skip_rv_clockwork) {
     cout << "Printing buffer information..." << endl;
 
     // Calculate dependencies here...

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2866,7 +2866,11 @@ CoreIR::Module*  generate_coreir_without_ctrl(CodegenOptions& options,
       auto lowering_information = impl.lowering_info;
 
       const char* dense_ready_valid = std::getenv("DENSE_READY_VALID");
-      if (dense_ready_valid && dense_ready_valid[0] == '1') {
+      bool skip_rv_clockwork = (std::getenv("SKIP_RV_CLOCKWORK") != nullptr) && (std::getenv("SKIP_RV_CLOCKWORK")[0] == '1');
+      if (skip_rv_clockwork) {
+        cout << "SKIP RV CLOCKWORK" << endl;
+      }
+      if (dense_ready_valid && dense_ready_valid[0] == '1' && !skip_rv_clockwork) {
         cout << "POPULATING DEPENDENCIES ON LOWERED BUFFER" << endl;
         for(auto l : lowering_information){
           impl.lowering_info.at(l.first).target_buf.populate_rv_deps(true);

--- a/ubuffer.cpp
+++ b/ubuffer.cpp
@@ -4565,7 +4565,11 @@ CoreIR::Instance* UBuffer::map_ubuffer_to_cgra(CodegenOptions& options, CoreIR::
     }
     config_file = generate_ubuf_args(options, hw_impl.sub_component);
     const char* dense_ready_valid = std::getenv("DENSE_READY_VALID");
-    if (dense_ready_valid && dense_ready_valid[0] == '1') {
+    bool skip_rv_clockwork = (std::getenv("SKIP_RV_CLOCKWORK") != nullptr) && (std::getenv("SKIP_RV_CLOCKWORK")[0] == '1');
+    if (skip_rv_clockwork) {
+      cout << "SKIP RV CLOCKWORK" << endl;
+    }
+    if (dense_ready_valid && dense_ready_valid[0] == '1' && !skip_rv_clockwork) {
       cout << "Add rv information to buffer..." << endl;
       config_file = add_rv_info_to_json(config_file, hw_impl.target_buf);
     }


### PR DESCRIPTION
Adds a switch to turn off RV clockwork compilation, which is used in maxpooling.
AHA PR: https://github.com/StanfordAHA/aha/pull/2087